### PR TITLE
テーブル作定義変更時、PRにDATABASE利用規約リンクを表示して確認を促す

### DIFF
--- a/.github/workflows/comment_to_pr_if_change_databases.yml
+++ b/.github/workflows/comment_to_pr_if_change_databases.yml
@@ -1,0 +1,21 @@
+name: Comment to PR if change databases
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'database/schemas/**.schema'
+
+jobs:
+  coment-to-pr:
+    name: Comment to PR
+    if: ${{ github.actor != 'dependabot[bot]' && github.head_ref != 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: db-schema-change
+          message: |
+            テーブル定義変更時には[DATABASE利用規約](https://)を確認してください


### PR DESCRIPTION
## Description
### WHAT (Purpose of this PR)
- DATABASE利用規約はテーブル定義変更時に読めば十分なので、PRを立てた時にリマインドして確認を促します。

### WHY (Implementation design / reason)
- DATABASE利用規約が認知されていない か 存在を忘れられ、DATABASE利用規約が参照されない状態にならないようにするため

対象のブランチやファイルパスなどの設定はプロジェクトによって調整する必要があります。